### PR TITLE
meta-iotqa: Disable nftables test with QEMU

### DIFF
--- a/meta-iotqa/conf/test/qemu.mask
+++ b/meta-iotqa/conf/test/qemu.mask
@@ -2,5 +2,6 @@
 # /docker/tester-exec.sh will use this file to remove tests from a manifest
 oeqa.runtime.sanity.comm_btcheck
 oeqa.runtime.sanity.comm_wifi_connect
+oeqa.runtime.sanity.nftables
 oeqa.runtime.sanity.mraa_gpio
 oeqa.runtime.alsa.alsa


### PR DESCRIPTION
It doesn't work with the way QEMU is tested so disable it.

Signed-off-by: Simo Kuusela <simo.kuusela@intel.com>